### PR TITLE
Remove unused variable in pagination template

### DIFF
--- a/seafoam/templates/includes/pagination.html
+++ b/seafoam/templates/includes/pagination.html
@@ -6,7 +6,6 @@
     <div class="text-center">
         <ul class="pagination">
             {% if articles_page.has_previous() %}
-                {% set num = articles_page.previous_page_number() %}
                 <li class="prev">
                     <a href="{{ SITEURL }}/{{ articles_previous_page.url }}">
                         <i class="fa fa-arrow-circle-left"></i>


### PR DESCRIPTION
The variable `num` gets overwritten later in the for loop and is not used.